### PR TITLE
Updated project to support .Net 4.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Zxcvbn C#/.NET
 ==============
 
-[![Build status](https://ci.appveyor.com/api/projects/status/ji4rr97d6rbxycw4?svg=true)](https://ci.appveyor.com/project/trichards57/zxcvbn-cs)
-[![Coverage Status](https://coveralls.io/repos/github/trichards57/zxcvbn-cs/badge.svg?branch=new%2Fnetstandard10)](https://coveralls.io/github/trichards57/zxcvbn-cs)
+[![Build status](https://ci.appveyor.com/api/projects/status/ji4rr97d6rbxycw4?svg=true)](https://ci.appveyor.com/project/trichards57/zxcvbn-cs-62692)
+[![Coverage Status](https://coveralls.io/repos/github/trichards57/zxcvbn-cs/badge.svg?branch=master)](https://coveralls.io/github/trichards57/zxcvbn-cs?branch=master)
 [![NuGet](https://img.shields.io/nuget/v/zxcvbn-core.svg)](https://www.nuget.org/packages/zxcvbn-core)
 
 This is a port of the `Zxcvbn` JavaScript password strength estimation library at

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.0.{build}
+version: 2.1.{build}
 image: Visual Studio 2017
 init:
   - git config --global core.autocrlf true

--- a/zxcvbn-core/zxcvbn-core.csproj
+++ b/zxcvbn-core/zxcvbn-core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>C#/.NET port of Dan Wheeler/DropBox's Zxcvbn JS password strength estimation library.  Updated for .Net Core.</Description>
     <Authors>mickford;Tony Richards (trichards57);Dan Wheeler;DropBox</Authors>
-    <TargetFrameworks>netstandard2.0;net452;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net451;netstandard1.6</TargetFrameworks>
     <AssemblyName>zxcvbn-core</AssemblyName>
     <PackageId>zxcvbn-core</PackageId>
     <PackageTags>password;strength;validation;zxcvbn</PackageTags>


### PR DESCRIPTION
Update core library to target .Net 4.5.1 instead of 4.5.2.

Test library still targets 4.5.2, but looking at the differences between the two libraries, this is not a real concern.

Closes #15 
