### PR TITLE
Fixed log base in SequenceMatcher for uppercase sequences.

### DIFF
--- a/Matcher/SequenceMatcher.cs
+++ b/Matcher/SequenceMatcher.cs
@@ -100,7 +100,7 @@ namespace Zxcvbn.Matcher
             if (firstChar == 'a' || firstChar == '1') baseEntropy = 1;
             else if ('0' <= firstChar && firstChar <= '9') baseEntropy = Math.Log(10, 2); // Numbers
             else if ('a' <= firstChar && firstChar <= 'z') baseEntropy = Math.Log(26, 2); // Lowercase
-            else baseEntropy = Math.Log(26, 1) + 1; // + 1 for uppercase
+            else baseEntropy = Math.Log(26, 2) + 1; // + 1 for uppercase
 
             if (!ascending) baseEntropy += 1; // Descending instead of ascending give + 1 bit of entropy
 


### PR DESCRIPTION
Looks like there is a small typo in the SequenceMatcher for uppercase entropy calculation. This leads to a NaN entropy for uppercase sequences, and they're simply ignored in the match selection (FindMinimumEntropyMatch). 