### PR TITLE
Fixing DictionaryMatcher.cs comment on frequency

### DIFF
--- a/zxcvbn-core/Matcher/DictionaryMatcher.cs
+++ b/zxcvbn-core/Matcher/DictionaryMatcher.cs
@@ -107,7 +107,7 @@ namespace Zxcvbn.Matcher
                 if (actualWord.Contains(" "))
                     actualWord = actualWord.Split(new[] { " " }, StringSplitOptions.RemoveEmptyEntries)[0];
 
-                // The word list is assumed to be in increasing frequency order
+                // The word list is assumed to be in decreasing frequency order
                 dict[actualWord] = i++;
             }
 


### PR DESCRIPTION
The first word in the dictionary has a rank of 1 and it is therefore the most frequent one.