### PR TITLE
Fixed recognition of all-caps

### DIFF
--- a/zxcvbn-core-test/Core/CoreTests.cs
+++ b/zxcvbn-core-test/Core/CoreTests.cs
@@ -56,5 +56,27 @@ namespace Zxcvbn.Tests.Core
             var warning = "Names and surnames by themselves are easy to guess";
             result.Feedback.Warning.Should().BeEquivalentTo(warning);
         }
+
+        [Fact]
+        public void AllUppercaseShouldBeRecognisedDistinctFromCapitalisation()
+        {
+            // Capitalization
+            var result = Zxcvbn.Core.EvaluatePassword("Where");
+            var defaultFeedback = new[]
+            {
+                "Add another word or two.  Uncommon words are better.",
+                "Capitalization doesn't help very much",
+            };
+            result.Feedback.Suggestions.Should().BeEquivalentTo(defaultFeedback);
+            
+            // All uppercase
+            result = Zxcvbn.Core.EvaluatePassword("WHERE");
+            defaultFeedback = new[]
+            {
+                "Add another word or two.  Uncommon words are better.",
+                "All-uppercase is almost as easy to guess as all-lowercase",
+            };
+            result.Feedback.Suggestions.Should().BeEquivalentTo(defaultFeedback);
+        }
     }
 }

--- a/zxcvbn-core/Feedback.cs
+++ b/zxcvbn-core/Feedback.cs
@@ -94,10 +94,10 @@ namespace Zxcvbn
 
             var suggestions = new List<string>();
             var word = match.Token;
-            if (char.IsUpper(word[0]))
-                suggestions.Add("Capitalization doesn't help very much");
-            else if (word.All(c => char.IsUpper(c)) && word.ToLower() != word)
+            if (word.All(char.IsUpper) && word.ToLower() != word)
                 suggestions.Add("All-uppercase is almost as easy to guess as all-lowercase");
+            else if (char.IsUpper(word[0]))
+                suggestions.Add("Capitalization doesn't help very much");
 
             if (match.Reversed && match.Token.Length >= 4)
                 suggestions.Add("Reversed words aren't much harder to guess");

--- a/zxcvbn-core/Feedback.cs
+++ b/zxcvbn-core/Feedback.cs
@@ -94,7 +94,7 @@ namespace Zxcvbn
 
             var suggestions = new List<string>();
             var word = match.Token;
-            if (word.All(char.IsUpper) && word.ToLower() != word)
+            if (word.All(c => char.IsUpper(c)) && word.ToLower() != word)
                 suggestions.Add("All-uppercase is almost as easy to guess as all-lowercase");
             else if (char.IsUpper(word[0]))
                 suggestions.Add("Capitalization doesn't help very much");


### PR DESCRIPTION
The existing code was guaranteed to never recognise all-caps because it was in an else block from the first character being caps.

By switching the clauses it only tests for first letter uppercase after it has confirmed that it isn't entirely uppercase.